### PR TITLE
HOTFIX correct key for directories with names ending in regex match

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ const crawl = async function (dirname, stripextension, filetest) {
 };
 
 const merge = function (dirname = Path.resolve(Path.dirname(Caller())), extensions = ['.json'], callback) {
-    const extregex = `.(${extensions.join('|')})$`;
+    const extregex = `\\.(${extensions.map(ext => ext.replace('.', '\\.')).join('|')})$`;
     const stripextension = RegExp(extregex, 'g');
     const filetest = RegExp(`^.*${extregex}`);
 


### PR DESCRIPTION
For example, the file extension `ts` causes a directory named `documents` to have a key `docume`. This hotfix ensures that key has the correct value in such situations.